### PR TITLE
Fix issue with count in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,9 @@ if [ -z "$dependency_updates" ];
 then
   message="Congratulations, all your plugins have the latest releases! 🥳"
 else
-  dependency_updates=$(echo "$dependency_updates" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
   countOutdated=$(echo "$dependency_updates" | wc -l)
-  message="**You have $countOutdated plugins with newer available releases:**\n$dependency_updates"
+  dependency_updates=$(echo "$dependency_updates" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
+  message="**You have $countOutdated dependencies and plugins with newer releases available:**\n$dependency_updates"
 fi
 
 curl \


### PR DESCRIPTION
The count of dependency updates should occur before sed is applied as this converts it to a single line
(The same fix was applied to the gradle version of this action: https://github.com/raulpadilladelgado/check-dependencies-in-pr-action)